### PR TITLE
Adapt to Jakarta Mail changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>4.18</version>
+		<version>4.42</version>
 		<relativePath />
 	</parent>
 	<artifactId>test-results-aggregator</artifactId>
@@ -13,8 +14,7 @@
 	<description>Aggregate Test and Job Results in a single HTML/email report.</description>
 	<url>https://github.com/jenkinsci/test-results-aggregator-plugin</url>
 	<properties>
-		<jenkins.version>2.277</jenkins.version>
-		<java.level>8</java.level>
+		<jenkins.version>2.332.1</jenkins.version>
 	</properties>
 	<licenses>
 		<license>
@@ -49,21 +49,29 @@
 			<url>https://repo.jenkins-ci.org/public/</url>
 		</pluginRepository>
 	</pluginRepositories>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>io.jenkins.tools.bom</groupId>
+				<artifactId>bom-2.332.x</artifactId>
+				<version>1500.ve4d05cd32975</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 	<dependencies>
 		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
-			<version>2.13.2</version>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>jackson2-api</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>junit</artifactId>
-			<version>1.21</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>mailer</artifactId>
-			<version>1.21</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/src/main/java/com/jenkins/testresultsaggregator/helper/Validate.java
+++ b/src/main/java/com/jenkins/testresultsaggregator/helper/Validate.java
@@ -2,10 +2,10 @@ package com.jenkins.testresultsaggregator.helper;
 
 import java.util.Properties;
 
-import javax.mail.AuthenticationFailedException;
-import javax.mail.MessagingException;
-import javax.mail.Session;
-import javax.mail.Transport;
+import jakarta.mail.AuthenticationFailedException;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.Transport;
 
 public class Validate {
 	

--- a/src/main/java/com/jenkins/testresultsaggregator/reporter/MailNotification.java
+++ b/src/main/java/com/jenkins/testresultsaggregator/reporter/MailNotification.java
@@ -14,14 +14,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.mail.Message.RecipientType;
-import javax.mail.MessagingException;
-import javax.mail.Multipart;
-import javax.mail.Transport;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeBodyPart;
-import javax.mail.internet.MimeMessage;
-import javax.mail.internet.MimeMultipart;
+import jakarta.mail.Message.RecipientType;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Multipart;
+import jakarta.mail.Transport;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeBodyPart;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMultipart;
 
 import com.google.common.base.Strings;
 import com.jenkins.testresultsaggregator.data.Data;


### PR DESCRIPTION
Recent versions of the Mailer plugin, on which this plugin depends, have switched from JavaMail to Jakarta Mail. This PR adapts this plugin accordingly for compatibility. Without this PR, I suspect this plugin is broken when used with recent versions of the Mailer plugin, so a timely merge and release of this PR would be appreciated.

CC @sdrss